### PR TITLE
Remove paths-ignore from CI so all PRs run integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '*.md'
-      - 'docs/**'
 
 jobs:
 


### PR DESCRIPTION
## Summary
- Removes `paths-ignore` from the CI workflow trigger
- CI now runs on every PR to `main` without exception
- Fixes the gap where docs-only or mixed PRs could bypass the required `Integration tests` check and merge without CI running

## Test plan
- [x] This PR itself triggers the `Integration tests` check on GitHub Actions
- [x] Check passes and PR is mergeable only after CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)