### PR TITLE
Bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Create .env from the example — default credentials are safe for CI
       - name: Create .env
@@ -48,7 +48,7 @@ jobs:
           done
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,13 +26,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/configure-pages@v4
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: lab-guide/
 
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deploy


### PR DESCRIPTION
## Summary
Bumps all GitHub Actions to versions that run on Node.js 24, resolving deprecation warnings ahead of GitHub's forced migration deadline (June 2026).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v4 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |

## Test plan
- [ ] CI (`Integration tests`) passes on this PR
- [ ] After merge, trigger a manual Pages deploy to confirm `deploy-pages.yml` works with updated actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)