### PR TITLE
Fix Apache Combined log field extraction for buttercup_web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,24 @@ All runtime config lives in `.env` (gitignored). See `.env.example` for the full
 
 - **Do not name data files with a `.log` extension.** The Splunk Docker image silently blocks all `.log` files under `/opt/splunk/etc/` from being monitored — they never appear in `splunk list monitor` and are never indexed. Use `.txt`, `.csv`, or any other extension instead.
 
+## GitHub token scopes
+
+The `gh` CLI is used throughout this repo for PRs, branch protection, CI checks, and triggering workflows. The personal access token needs these scopes:
+
+| Scope | Required for |
+|---|---|
+| `repo` | Push/pull, branch protection rules, PRs, issues |
+| `workflow` | Triggering `workflow_dispatch` (e.g. manual GitHub Pages deploy) |
+| `read:org` | `gh pr` and `gh run` commands |
+
+To update scopes: **GitHub → Settings → Developer settings → Personal access tokens**.
+
+To manually trigger a Pages redeploy (e.g. after workflow changes that didn't touch `lab-guide/`):
+
+```bash
+gh workflow run deploy-pages.yml --ref main
+```
+
 ## Security posture
 
 This lab is intentionally insecure for local demo use:

--- a/buttercup_app/default/props.conf
+++ b/buttercup_app/default/props.conf
@@ -15,3 +15,4 @@ SHOULD_LINEMERGE = false
 LINE_BREAKER = ([\r\n]+)
 DATETIME_CONFIG = CURRENT
 KV_MODE = none
+EXTRACT-apache = ^(?P<clientip>\S+)\s+\S+\s+\S+\s+\[(?P<date>[^\]]+)\]\s+"(?P<method>\w+)\s+(?P<uri>\S+)\s+\S+"\s+(?P<status>\d+)\s+(?P<bytes>\S+)\s+"(?P<referer>[^"]*)"\s+"(?P<useragent>[^"]*)"

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -97,6 +97,17 @@ class TestButtercupData:
         assert len(parts) == 5, \
             f"Expected 5 CSV fields (date,vendor,product,units_sold,revenue), got {len(parts)}: {raw}"
 
+    def test_web_status_field_extracted(self, buttercup_ready, splunk_session):
+        """Apache Combined log field extraction should populate the status field."""
+        results = run_search(
+            splunk_session,
+            "search index=buttercup sourcetype=buttercup_web | stats count by status | where status!=\"\"",
+        )
+        assert results, \
+            "No status values extracted from buttercup_web — check EXTRACT-apache in props.conf"
+        statuses = {r["status"] for r in results}
+        assert statuses, "status field is empty on all buttercup_web events"
+
 
 # ── HTTP Event Collector ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `EXTRACT-apache` regex to `props.conf` for `buttercup_web` sourcetype
- Extracts `clientip`, `method`, `uri`, `status`, `bytes`, `referer`, `useragent` from Apache Combined log format
- Fixes the lab-guide SPL query `index=buttercup sourcetype=buttercup_web | stats count by status` which was returning no results because `status` was never parsed
- Adds `test_web_status_field_extracted` to CI to catch regressions

## Root cause
`props.conf` had `KV_MODE = none` but no `EXTRACT` directive — raw events were indexed correctly but no fields were extracted, so any field-based SPL returned empty results.

## Test plan
- [x] CI passes (11 tests including new `test_web_status_field_extracted`)
- [x] After merge, verify the status query in the lab guide returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)