### PR TITLE
Sync README and CLAUDE.md with current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,24 @@ docker compose down -v
 # Rebuild the MCP server image after changes to mcp/Dockerfile
 docker compose build splunk-mcp
 
+# Rebuild the status-api image after changes to status-api/
+docker compose build status-api
+
 # Check container health
 docker compose ps
 ```
 
 ## Architecture
 
-Two services run in Docker Compose:
+Four services run in Docker Compose:
 
-- **splunk** (`splunk/splunk:latest`) — Splunk Enterprise. All ports bound to `127.0.0.1`. Data persisted in the `splunk-var` named volume. The `buttercup_app/` directory is bind-mounted into `/opt/splunk/etc/apps/buttercup_app` and auto-indexed on first boot.
+- **splunk** (`splunk/splunk:10.2.1`) — Splunk Enterprise. All ports bound to `127.0.0.1`. Data persisted in the `splunk-var` named volume. The `buttercup_app/` directory is bind-mounted into `/opt/splunk/etc/apps/buttercup_app` and auto-indexed on first boot.
 
 - **splunk-mcp** (built from `mcp/Dockerfile`) — Official Splunk MCP server (`splunk-mcp-server` npm package). Runs in SSE mode on `127.0.0.1:8050`. Connects to Splunk via internal Docker networking on `splunk:8089`. No MCP endpoint auth — localhost-only by design.
+
+- **lab-guide** (`nginx:alpine`) — Static lab guide served at `127.0.0.1:3000`. Mounts `lab-guide/` as the web root and `lab-guide/nginx.conf` as the nginx config. Proxies `/api/status` to `status-api:8081` so the status dashboard can poll from the browser without a separate port.
+
+- **status-api** (built from `status-api/Dockerfile`) — Python sidecar that exposes `GET /api/status` on port 8081 (internal only). Uses the Docker SDK via a read-only `docker.sock` mount to check container states and probes Splunk Web and MCP HTTP endpoints for service health.
 
 ## Buttercup app
 
@@ -49,7 +56,7 @@ Two services run in Docker Compose:
 
 - `default/inputs.conf` — `monitor://` stanzas that tell Splunk to watch the `data/` directory
 - `default/props.conf` — CSV parsing config for the two CSV sourcetypes
-- `data/` — the actual sample files (`access.log`, `vendor_sales.csv`, `products.csv`)
+- `data/` — the actual sample files (`buttercup_access.txt`, `vendor_sales.csv`, `products.csv`)
 
 Data lands in the `buttercup` index under sourcetypes `buttercup_web`, `buttercup_sales`, and `buttercup_products`.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Buttercup Games sample data is automatically indexed at startup — no manual st
 
 ### Buttercup Games sample data
 
-Three datasets are auto-indexed into the `main` index:
+Three datasets are auto-indexed into the `buttercup` index:
 
 | Sourcetype | Description |
 |---|---|
@@ -90,6 +90,16 @@ index=buttercup sourcetype=buttercup_sales | stats sum(units_sold) as total_unit
 index=buttercup sourcetype=buttercup_sales | timechart span=1d sum(revenue) by vendor
 ```
 
+### Lab Guide and Status Dashboard
+
+The lab guide runs at `http://localhost:3000` and serves as the single interface for the lab:
+
+- **Steps 1–3** — click-through setup and guided SPL exercises
+- **Status** — live dashboard showing container health, Splunk Web and MCP service reachability, and OpenTelemetry stack placeholders (auto-refreshes every 10s)
+- **Documentation** — reference material for the lab
+
+The status backend (`status-api`) runs as a sidecar container and exposes `GET /api/status` via the nginx reverse proxy — no separate port required.
+
 ---
 
 ## Importing your own data
@@ -104,7 +114,7 @@ index=buttercup sourcetype=buttercup_sales | timechart span=1d sum(revenue) by v
 
 Your data is immediately searchable:
 ```spl
-index=buttercup sourcetype=csv | head 20
+index=main sourcetype=csv | head 20
 ```
 
 ### From an online source (HEC)
@@ -127,7 +137,7 @@ curl -k https://localhost:8088/services/collector/event \
 
 Then search for your events:
 ```spl
-index=buttercup sourcetype=my_sourcetype
+index=main sourcetype=my_sourcetype
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Fix index name in README (`main` → `buttercup`) for Buttercup sample data
- Fix CSV import search examples to use `index=main` (matching the import instructions)
- Add lab guide and status dashboard description to What's included
- CLAUDE.md: expand architecture from two to four services (add `lab-guide` and `status-api`)
- CLAUDE.md: fix Splunk image tag (`latest` → `10.2.1`)
- CLAUDE.md: fix data filename (`access.log` → `buttercup_access.txt`)
- CLAUDE.md: add `status-api` rebuild command

## Test plan

- [x] CI passes
- [ ] Docs accurately describe the running stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)