### PR TITLE
Update MCP integration to use mcp-remote

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,44 @@ Data lands in the `buttercup` index under sourcetypes `buttercup_web`, `buttercu
 
 All runtime config lives in `.env` (gitignored). See `.env.example` for the full reference. The only required variable is `SPLUNK_PASSWORD`. `SPLUNK_HEC_TOKEN` pre-sets the HEC token so it's known before boot.
 
+## MCP integration
+
+The project ships `.claude/settings.json` with the MCP server pre-configured for Claude Code — no `claude mcp add` required.
+
+**Why mcp-remote instead of `--transport sse`:**
+`claude mcp add --transport sse` requires an HTTPS endpoint. The lab MCP server serves plain HTTP on `localhost:8050`. Using `mcp-remote` as a stdio proxy avoids this — Claude Code communicates with it over stdio, and it forwards requests to `localhost:8050` over HTTP with no SSL involved.
+
+**Claude Code** — automatic via `.claude/settings.json` (committed in this repo):
+```json
+{
+  "mcpServers": {
+    "splunk": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
+    }
+  }
+}
+```
+
+**Claude Desktop** — one-time manual edit to the machine-local config:
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "splunk-lab": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+**Prerequisite:** Node.js must be installed on the host (for `npx`).
+
 ## Known gotchas
 
 - **Do not name data files with a `.log` extension.** The Splunk Docker image silently blocks all `.log` files under `/opt/splunk/etc/` from being monitored — they never appear in `splunk list monitor` and are never indexed. Use `.txt`, `.csv`, or any other extension instead.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Live health of all lab services — container states, Splunk Web and MCP reachab
 ## Prerequisites
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed and running
+- [Node.js](https://nodejs.org/) installed on the host machine (required for MCP integration)
 - Claude Code or Claude Desktop (for MCP integration)
 
 ---
@@ -164,22 +165,20 @@ The Splunk MCP server runs as a container alongside Splunk and exposes an SSE en
 
 > **Security note:** The MCP endpoint requires no authentication and is bound to `127.0.0.1` only — it is not accessible from other machines on the network. This configuration is intentional for local demo use. Do not expose port `8050` to external networks.
 
+> **Why mcp-remote?** Claude Code and Claude Desktop require HTTPS for direct SSE connections. Since the lab MCP server uses plain HTTP on localhost, [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) is used as a local stdio proxy — Claude talks to it over stdio, and it forwards requests to `localhost:8050` over HTTP. No SSL involved. Node.js must be installed on the host for `npx` to work.
+
 ### Claude Code
 
-Add the MCP server to your project:
+The project ships with `.claude/settings.json` pre-configured. No setup required — the MCP server is automatically available when you open Claude Code in the `splunk-lab` directory with the stack running.
 
-```bash
-claude mcp add --transport sse --scope project splunk http://localhost:8050/sse
-```
-
-Or add it manually to `.claude/settings.json`:
+If you need to add it manually:
 
 ```json
 {
   "mcpServers": {
     "splunk": {
-      "type": "sse",
-      "url": "http://localhost:8050/sse"
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
     }
   }
 }
@@ -192,19 +191,24 @@ Then start a conversation:
 
 ### Claude Desktop
 
-Add to your `claude_desktop_config.json` (open via **Claude Desktop → Settings → Developer**):
+Open your Claude Desktop config file:
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following `mcpServers` block:
 
 ```json
 {
   "mcpServers": {
-    "splunk": {
-      "url": "http://localhost:8050/sse"
+    "splunk-lab": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
     }
   }
 }
 ```
 
-Restart Claude Desktop — the Splunk tools will appear in the tool list.
+Restart Claude Desktop — the Splunk tools will appear in the tool list whenever the lab stack is running.
 
 ---
 

--- a/lab-guide/index.html
+++ b/lab-guide/index.html
@@ -616,16 +616,8 @@ cd splunk-lab</code>
 
             <!-- Claude Code -->
             <div class="tab-pane active" id="pane-code">
-                <h2>Add the MCP server</h2>
-                <p>Run this command from inside the <code>splunk-lab</code> directory:</p>
-                <div class="code-block">
-                    <div class="code-header">
-                        <span class="code-lang">bash</span>
-                        <button class="copy-btn" onclick="copyCode(this)">Copy</button>
-                    </div>
-                    <code>claude mcp add --transport sse --scope project splunk http://localhost:8050/sse</code>
-                </div>
-                <p>Or add it manually to <code>.claude/settings.json</code>:</p>
+                <h2>No setup required</h2>
+                <p>The project ships with <code>.claude/settings.json</code> pre-configured. Open Claude Code in the <code>splunk-lab</code> directory with the stack running — the Splunk MCP tools are automatically available.</p>
                 <div class="code-block">
                     <div class="code-header">
                         <span class="code-lang">json</span>
@@ -634,12 +626,13 @@ cd splunk-lab</code>
                     <code>{
   "mcpServers": {
     "splunk": {
-      "type": "sse",
-      "url": "http://localhost:8050/sse"
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
     }
   }
 }</code>
                 </div>
+                <p class="note">Requires <strong>Node.js</strong> on the host for <code>npx</code>. The MCP server uses <code>mcp-remote</code> as a local proxy — Claude Code communicates over stdio, avoiding the HTTPS requirement for direct SSE connections.</p>
                 <h2>Try these prompts</h2>
                 <div class="card">
                     <ul class="prompt-list">
@@ -654,7 +647,11 @@ cd splunk-lab</code>
             <!-- Claude Desktop -->
             <div class="tab-pane" id="pane-desktop">
                 <h2>Add the MCP server</h2>
-                <p>Open Claude Desktop, go to <strong>Settings → Developer</strong>, then edit <code>claude_desktop_config.json</code>:</p>
+                <p>Open your Claude Desktop config file and add the <code>mcpServers</code> block:</p>
+                <ul style="margin:0 0 1rem 1.25rem; color:var(--text-muted); font-size:0.875rem;">
+                    <li><strong>macOS:</strong> <code>~/Library/Application Support/Claude/claude_desktop_config.json</code></li>
+                    <li><strong>Windows:</strong> <code>%APPDATA%\Claude\claude_desktop_config.json</code></li>
+                </ul>
                 <div class="code-block">
                     <div class="code-header">
                         <span class="code-lang">json</span>
@@ -662,13 +659,15 @@ cd splunk-lab</code>
                     </div>
                     <code>{
   "mcpServers": {
-    "splunk": {
-      "url": "http://localhost:8050/sse"
+    "splunk-lab": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@0.1.38", "http://localhost:8050/sse"]
     }
   }
 }</code>
                 </div>
-                <p>Restart Claude Desktop — the Splunk tools will appear in the tool list.</p>
+                <p>Restart Claude Desktop — the Splunk tools will appear in the tool list whenever the lab stack is running.</p>
+                <p class="note">Requires <strong>Node.js</strong> on the host for <code>npx</code>.</p>
                 <h2>Try these prompts</h2>
                 <div class="card">
                     <ul class="prompt-list">


### PR DESCRIPTION
## Summary

- Switches MCP client config from direct `--transport sse` (requires HTTPS) to `mcp-remote` stdio proxy (works with plain HTTP localhost)
- **Claude Code**: zero-touch — `.claude/settings.json` ships in the repo, auto-configured on clone
- **Claude Desktop**: one-time config edit documented for macOS and Windows
- Adds Node.js as a prerequisite (needed for `npx`)
- Documents *why* mcp-remote is needed in README, CLAUDE.md, and lab-guide

## Test plan

- [ ] Follow the Claude Code instructions — confirm MCP tools available without any `claude mcp add` command
- [ ] Follow the Claude Desktop instructions — confirm tools appear after restart
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)