### PR TITLE
Add OpenTelemetry Demo stack bridge to Splunk (HEC / otel index)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ SPLUNK_PASSWORD=Chang3d!
 # ── HTTP Event Collector ───────────────────────────────────────────────────
 # Pre-set HEC token so you can send events without navigating the Splunk UI.
 # Use any UUID-format string, or generate one: uuidgen
+# Also used by the optional OpenTelemetry Demo bridge (otel-demo/README.md).
 SPLUNK_HEC_TOKEN=a8b4c2d6-e0f1-4321-9876-abcdef012345
 
 # ── Web ports ─────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,10 @@ docker compose down
 # Full reset — wipe all indexed data
 docker compose down -v
 
+# Splunk + shared Docker network for the optional OpenTelemetry Demo (see otel-demo/README.md)
+docker network create splunk-lab-otel 2>/dev/null || true
+docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml up -d
+
 # Rebuild the MCP server image after changes to mcp/Dockerfile
 docker compose build splunk-mcp
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ Then search for your events:
 index=main sourcetype=my_sourcetype
 ```
 
+### OpenTelemetry Demo (optional)
+
+Run the **[official OpenTelemetry Astronomy Shop](https://github.com/open-telemetry/opentelemetry-demo)** as a **separate** Docker Compose project and forward **traces, metrics, and logs** into Splunk via HEC (`index=otel`, sourcetype `otel_demo`).
+
+1. Create a shared network: `docker network create splunk-lab-otel`
+2. Start Splunk with the bridge file: `docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml up -d`
+3. Clone the demo (pin to **2.1.3** or see compatibility notes) and run **`otel-demo/start-with-splunk.sh`**
+
+Full steps, manual `docker compose` overrides, and upgrade notes: **[otel-demo/README.md](otel-demo/README.md)**.
+
 ---
 
 ## Ask Splunk

--- a/buttercup_app/default/indexes.conf
+++ b/buttercup_app/default/indexes.conf
@@ -3,3 +3,9 @@
 homePath   = $SPLUNK_DB/buttercup/db
 coldPath   = $SPLUNK_DB/buttercup/colddb
 thawedPath = $SPLUNK_DB/buttercup/thaweddb
+
+# OpenTelemetry Demo → HEC (splunk_hec exporter). Small demo volume; tune retention as needed.
+[otel]
+homePath   = $SPLUNK_DB/otel/db
+coldPath   = $SPLUNK_DB/otel/colddb
+thawedPath = $SPLUNK_DB/otel/thaweddb

--- a/docker-compose.otel-bridge.yml
+++ b/docker-compose.otel-bridge.yml
@@ -1,0 +1,19 @@
+# Optional Compose fragment: attach Splunk to a shared Docker network so other stacks
+# (e.g. the OpenTelemetry Demo) can reach it by hostname "splunk" on port 8088 (HEC).
+#
+# Usage (from this repo root, after a normal .env is configured):
+#   docker network create splunk-lab-otel 2>/dev/null || true
+#   docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml up -d
+#
+# The lab guide, MCP, and Splunk Web stay on localhost-only ports as in the base file.
+
+networks:
+  splunk-lab-otel:
+    name: splunk-lab-otel
+    driver: bridge
+
+services:
+  splunk:
+    networks:
+      - default
+      - splunk-lab-otel

--- a/otel-demo/README.md
+++ b/otel-demo/README.md
@@ -1,0 +1,85 @@
+# OpenTelemetry Demo + Splunk Lab
+
+This folder wires the **[OpenTelemetry Astronomy Shop demo](https://github.com/open-telemetry/opentelemetry-demo)** into the Splunk lab: the demo’s **otel-collector** forwards **traces, metrics, and logs** to Splunk **HTTP Event Collector (HEC)** into the **`otel`** index.
+
+The demo itself is **not** vendored here. Clone it next to this repo or anywhere on disk, pinned to a release that matches the collector snippet below.
+
+## Supported demo version
+
+| Demo tag | Notes |
+|----------|--------|
+| **2.1.3** | Validated against `src/otel-collector/otelcol-config.yml` pipelines in that tag. When you upgrade the demo, diff that file against `otelcol-config-splunk-hec.yml` and align `receivers` / `processors` / `exporters` lists. |
+
+## Prerequisites
+
+- Splunk lab running with the **bridge** overlay so Splunk joins `splunk-lab-otel` (see below).
+- Same **`SPLUNK_HEC_TOKEN`** in the lab `.env` as Splunk was started with (see `.env.example`).
+- Docker resources per the [upstream demo docs](https://opentelemetry.io/docs/demo/docker-deployment/) (roughly **6 GB RAM** for the full stack).
+
+## Quick start
+
+**1. Create the shared Docker network** (once):
+
+```bash
+docker network create splunk-lab-otel
+```
+
+**2. Start the Splunk lab on that network**
+
+From the **splunk-lab repo root**:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml up -d
+```
+
+**3. Clone the OpenTelemetry Demo** (pinned):
+
+```bash
+git clone --branch 2.1.3 --depth 1 https://github.com/open-telemetry/opentelemetry-demo.git
+cd opentelemetry-demo
+```
+
+**4. Start the demo with Splunk export**
+
+From **splunk-lab** repo root (adjust path to your clone):
+
+```bash
+chmod +x otel-demo/start-with-splunk.sh
+OTEL_DEMO_DIR=/path/to/opentelemetry-demo ./otel-demo/start-with-splunk.sh
+```
+
+Or manually:
+
+```bash
+export OTEL_COLLECTOR_CONFIG_EXTRAS=/absolute/path/to/splunk-lab/otel-demo/otelcol-config-splunk-hec.yml
+cd /path/to/opentelemetry-demo
+docker compose \
+  -f docker-compose.yml \
+  -f /absolute/path/to/splunk-lab/otel-demo/docker-compose.docker-bridge.yml \
+  --env-file /absolute/path/to/splunk-lab/.env \
+  up -d
+```
+
+## Splunk searches
+
+After traffic runs (browse the storefront at **http://localhost:8080** or wait for the load generator):
+
+```spl
+index=otel | head 20
+```
+
+Traces and JSON-heavy fields are easiest to inspect in **Verbose** or **Raw** mode.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `otelcol-config-splunk-hec.yml` | Second collector config: adds `splunk_hec` exporter and extends pipelines. |
+| `docker-compose.docker-bridge.yml` | Demo override: `otel-collector` joins `splunk-lab-otel`, sets `SPLUNK_HEC_URL`. |
+| `start-with-splunk.sh` | Creates network if needed, starts lab with bridge, starts demo with overrides. |
+
+## Troubleshooting
+
+- **`Connection refused` to `splunk:8088`** — Splunk was not started with `docker-compose.otel-bridge.yml`, or the `splunk-lab-otel` network does not exist.
+- **401 from HEC** — Token in `.env` does not match the token Splunk was bootstrapped with; fix `.env` and restart Splunk, or align the token in Splunk’s HEC settings.
+- **No events in `otel`** — Confirm the collector started: `docker logs otel-collector`. After upgrading the demo, re-check pipeline names in `otelcol-config-splunk-hec.yml` against upstream `otelcol-config.yml`.

--- a/otel-demo/docker-compose.docker-bridge.yml
+++ b/otel-demo/docker-compose.docker-bridge.yml
@@ -1,0 +1,23 @@
+# OpenTelemetry Demo override: join the Splunk lab bridge network and pass HEC settings
+# into the collector. Use together with start-with-splunk.sh or:
+#
+#   docker network create splunk-lab-otel 2>/dev/null || true
+#   export OTEL_COLLECTOR_CONFIG_EXTRAS=/absolute/path/to/splunk-lab/otel-demo/otelcol-config-splunk-hec.yml
+#   docker compose -f docker-compose.yml -f /absolute/path/to/splunk-lab/otel-demo/docker-compose.docker-bridge.yml \
+#     --env-file /absolute/path/to/splunk-lab/.env up -d
+#
+# Requires SPLUNK_HEC_TOKEN in the env file (same value as the Splunk lab).
+
+networks:
+  splunk-lab-otel:
+    external: true
+    name: splunk-lab-otel
+
+services:
+  otel-collector:
+    networks:
+      - default
+      - splunk-lab-otel
+    environment:
+      - SPLUNK_HEC_TOKEN
+      - SPLUNK_HEC_URL=https://splunk:8088/services/collector

--- a/otel-demo/otelcol-config-splunk-hec.yml
+++ b/otel-demo/otelcol-config-splunk-hec.yml
@@ -1,0 +1,31 @@
+# Splunk HEC export for the OpenTelemetry Demo collector (otelcol contrib).
+# Loaded as the second --config file after the demo's otelcol-config.yml.
+#
+# Keep pipeline receivers/processors in sync with the demo's src/otel-collector/otelcol-config.yml
+# when upgrading IMAGE_VERSION (see otel-demo/README.md).
+
+exporters:
+  splunk_hec:
+    endpoint: ${env:SPLUNK_HEC_URL}
+    token: ${env:SPLUNK_HEC_TOKEN}
+    index: otel
+    sourcetype: otel_demo
+    use_multi_metric_format: true
+    tls:
+      insecure_skip_verify: true
+    timeout: 15s
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, transform, batch]
+      exporters: [otlp, debug, spanmetrics, splunk_hec]
+    metrics:
+      receivers: [docker_stats, httpcheck/frontend-proxy, hostmetrics, nginx, otlp, postgresql, redis, spanmetrics]
+      processors: [resourcedetection, memory_limiter, batch]
+      exporters: [otlphttp/prometheus, debug, splunk_hec]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, memory_limiter, batch]
+      exporters: [opensearch, debug, splunk_hec]

--- a/otel-demo/start-with-splunk.sh
+++ b/otel-demo/start-with-splunk.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Start the official OpenTelemetry Demo with the collector forwarding MELT to this Splunk lab via HEC.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LAB_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEMO_DIR="${OTEL_DEMO_DIR:-${1:-}}"
+
+if [[ -z "$DEMO_DIR" || ! -f "$DEMO_DIR/docker-compose.yml" ]]; then
+  echo "Usage: OTEL_DEMO_DIR=/path/to/opentelemetry-demo $0"
+  echo "   or: $0 /path/to/opentelemetry-demo"
+  echo ""
+  echo "Clone the demo first, pinned to a supported release (see otel-demo/README.md)."
+  exit 1
+fi
+
+ENV_FILE="$LAB_ROOT/.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Missing $ENV_FILE — copy .env.example and set SPLUNK_PASSWORD and SPLUNK_HEC_TOKEN."
+  exit 1
+fi
+
+if ! grep -qE '^SPLUNK_HEC_TOKEN=.+$' "$ENV_FILE" 2>/dev/null; then
+  echo "SPLUNK_HEC_TOKEN must be set in .env (non-empty)."
+  exit 1
+fi
+
+NETWORK_NAME="${SPLUNK_OTEL_NETWORK:-splunk-lab-otel}"
+docker network inspect "$NETWORK_NAME" &>/dev/null || docker network create "$NETWORK_NAME"
+
+echo "==> Ensuring Splunk lab is on bridge network $NETWORK_NAME"
+(
+  cd "$LAB_ROOT"
+  docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml --env-file "$ENV_FILE" up -d
+)
+
+export OTEL_COLLECTOR_CONFIG_EXTRAS="$SCRIPT_DIR/otelcol-config-splunk-hec.yml"
+
+echo "==> Starting OpenTelemetry Demo from $DEMO_DIR"
+cd "$DEMO_DIR"
+docker compose \
+  -f docker-compose.yml \
+  -f "$SCRIPT_DIR/docker-compose.docker-bridge.yml" \
+  --env-file "$ENV_FILE" \
+  up -d
+
+echo ""
+echo "Demo frontend (Envoy) is usually http://localhost:8080"
+echo "Splunk HEC index: otel — try: index=otel | head 20"

--- a/tests/test_lab.py
+++ b/tests/test_lab.py
@@ -38,6 +38,23 @@ class TestDockerCompose:
         )
         assert result.returncode == 0, result.stderr.decode()
 
+    def test_compose_otel_bridge_config_is_valid(self):
+        """Optional OTel bridge overlay must merge cleanly with the base compose file."""
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                "docker-compose.yml",
+                "-f",
+                "docker-compose.otel-bridge.yml",
+                "config",
+                "--quiet",
+            ],
+            capture_output=True,
+        )
+        assert result.returncode == 0, result.stderr.decode()
+
 
 # ── Splunk health ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an **optional** integration path so the **[official OpenTelemetry Demo](https://github.com/open-telemetry/opentelemetry-demo)** can run as its **own** Compose project while the **Splunk lab** receives **traces, metrics, and logs** through **HTTP Event Collector (HEC)** into a dedicated **`otel`** index.

## What changed

- **`docker-compose.otel-bridge.yml`** — attaches Splunk to a shared Docker network (`splunk-lab-otel`) so the demo collector can reach `https://splunk:8088/services/collector` without changing localhost-only port bindings on the default stack.
- **`buttercup_app/default/indexes.conf`** — defines an **`otel`** index for demo telemetry volume.
- **`otel-demo/`** — Splunk HEC collector extras (`splunk_hec` exporter), a small **override** for the upstream demo compose, **`start-with-splunk.sh`**, and **`README.md`** (pinned demo version **2.1.3**, upgrade notes).
- **`README.md`** / **`CLAUDE.md`** — short pointer to the full procedure.
- **`.env.example`** — notes that `SPLUNK_HEC_TOKEN` is shared with the bridge.
- **`tests/test_lab.py`** — validates `docker compose -f docker-compose.yml -f docker-compose.otel-bridge.yml config` merges cleanly.

## How to try it

See **`otel-demo/README.md`** — create `splunk-lab-otel`, start Splunk with the bridge file, clone demo **2.1.3**, run **`otel-demo/start-with-splunk.sh`**, then `index=otel` in Splunk.

## Testing

- `python3 -m pytest tests/test_lab.py::TestDockerCompose -v` (compose config validation; full stack tests were not run here — no Docker daemon in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70097dc-f36e-48a1-95f2-121d190f90ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70097dc-f36e-48a1-95f2-121d190f90ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

